### PR TITLE
Nest code samples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,51 +50,61 @@ Wouldn't it be cool if browsers let you do that? 🤔
 ## This is what Ponys allows you to do - in three different ways!
 
 - Detect any [`<template>`](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_templates_and_slots) elements that have a `name` attribute, and promote them to [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements):
-```html
-<script type="module">
-  import Ponys from './ponys.js';
-  Ponys.defineAll();
-</script>
 
-...
+  ```html
+  <script type="module">
+    import Ponys from './ponys.js';
+    Ponys.defineAll();
+  </script>
 
-<template name="hello-world">
-  Hello, <slot>world</slot>!
-</template>
-```
+  ...
+
+  <template name="hello-world">
+    Hello, <slot>world</slot>!
+  </template>
+  ```
+
 - Define a custom element by passing its name and its content as a string:
-```js
-/* app.js */
 
-import Ponys from './ponys.js';
+  ```js
+  /* app.js */
 
-Ponys.define('hello-world', 'Hello, <slot>world</slot>!');
-```
-- Import the content for a new custom element from a separate file:
-```html
-<!-- hello-world.html -->
-
-Hello, <slot>world</slot>!
-```
-  \- either through your app's JS:
-```js
-/* app.js */
-
-import Ponys from './ponys.js';
-
-Ponys.import('hello-world', './components/hello-world.html');
-```
-  \- or in your HTML, by adding a `src` attribute to a named template element:
-```html
-<script type="module">
   import Ponys from './ponys.js';
-  Ponys.defineAll();
-</script>
 
-...
+  Ponys.define('hello-world', 'Hello, <slot>world</slot>!');
+  ```
 
-<template name="hello-world" src="./components/hello-world.html"></template>
-```
+- Import the content for a new custom element from a separate file:
+
+  ```html
+  <!-- hello-world.html -->
+
+  Hello, <slot>world</slot>!
+  ```
+
+  - either through your app's JS:
+
+    ```js
+    /* app.js */
+
+    import Ponys from './ponys.js';
+
+    Ponys.import('hello-world', './components/hello-world.html');
+    ```
+
+  - or in your HTML, by adding a `src` attribute to a named template element:
+
+    ```html
+    <script type="module">
+      import Ponys from './ponys.js';
+      Ponys.defineAll();
+    </script>
+
+    ...
+
+    <template name="hello-world" src="./components/hello-world.html"></template>
+    ```
+
 That's correct: you can inline your templates server-side, create them dynamically, or import them as single-file components - each of these snippets results in the same custom element.
 
 ## But what about interactivity, styling, etc?


### PR DESCRIPTION
Some of the code samples in the README correspond to list items, but were not actually attached to the associated list items, and were instead top-level blocks. This is visually and semantically misleading.

This change nests each code block inside the corresponding list item, and unescapes two level-two bullets do they're actually rendered as list items. This way the structure of the resulting document matches the semantics of what the text actually says.