### PR TITLE
Add appropriate console warnings

### DIFF
--- a/ponys.js
+++ b/ponys.js
@@ -9,6 +9,7 @@ export default class {
 
 	static define(name, template, options, url = '')
 	{
+		if (customElements.get(name)) return Promise.reject(Error(`Component '${name}' already registered`));
 		if (!template.content) {
 			let templateElement = document.createElement('template');
 			templateElement.innerHTML = template;
@@ -18,6 +19,7 @@ export default class {
 		url = new URL(url, location.href);
 
 		let script = template.querySelector('script[setup]') || template.querySelector('script');
+		if (script && (!script.hasAttribute("setup") || script.type != "module")) console.warn("setup & type=module attributes expected");
 
 		return import(
 			'data:text/javascript;base64,' + btoa(
@@ -57,7 +59,10 @@ export default class {
 					this.import(options.name, options.src, options):
 					this.define(options.name, template, options);
 			})
-		);
+		).then(list => {
+			list?.filter(e => e.status !== "fulfilled")
+				.forEach(e => console.warn("import/define failed", e));
+		});
 	}
 
 	static import(name, url, options)


### PR DESCRIPTION
- warn when script setup and type=module tags are not used
    - Quoting [here](https://github.com/jhuddle/ponys/issues/5#issuecomment-2120916056), non-`setup` tags should be considered depreciated. I also felt that non-`type=module` should also be considered depreciated since the script can only ever by a module, which is likely to follow suite with an actual spec compliant implementation. Right now we just warn, later we can actually remove support.
- warn when component is already registered
- defineAll silently errors
    - `Promise.allSettled` always returns a fulfilled promise, regardless of whether or not each individual import/define fails, therefore the user never receives any console warnings to react to, therefore this will resolve that.