### PR TITLE
Modernize dynamic module URL import

### DIFF
--- a/ponys.js
+++ b/ponys.js
@@ -15,18 +15,16 @@ export default class {
 			template = templateElement;
 		}
 		template = template.content;
-		url = new URL(url, location.href);
+		url = new URL(url, location.href.startsWith('about:') ? document.baseURI : location.href);
 
 		let script = template.querySelector('script[setup]') || template.querySelector('script');
-
-		return import(
-			'data:text/javascript;base64,' + btoa(
-				script?.text?.replace(
-					/(import|from)\s*("|')(\.{0,2}\/.*?[^\\])\2/g,  // relative imports
-					(match, keyword, quote, path) => keyword + quote + new URL(path, url) + quote
-				)
-			)
-		).then(module => {
+		let moduleScript = script?.text?.replace(
+			/(import|from)\s*("|')(\.{0,2}\/.*?[^\\])\2/g,  // relative imports
+			(match, keyword, quote, path) => keyword + quote + new URL(path, url) + quote
+		);
+		let blobUrl = URL.createObjectURL(new Blob([moduleScript], { type: 'text/javascript' }));
+		
+		return import(`${blobUrl}#tag=${encodeURIComponent(name)}`).then(module => {
 			script?.remove();
 			class Component extends (module.default || HTMLElement) {
 				constructor() {
@@ -42,7 +40,7 @@ export default class {
 			}
 			customElements.define(name, Component, options);
 			return Component;
-		});
+		}).finally(_ => URL.revokeObjectURL(blobUrl));
 	}
 
 	static defineAll(container = document)


### PR DESCRIPTION
- Relative URL validation fails when using iframe srcdoc ([example fiddle](https://jsfiddle.net/L276cnja/))
- swap module script text loading from base64 encoded format to URL.createObjectURL() which produces a cleaner URL
   - The base64 method has potential limitations and performance degredation (see [here][0] and [here][1]), so this should avoid most all of that and is the modern equivalent anyhow.
   -  Additionally, appended component tag name as hash to generated URL (i.e. `blob:https://example.com/{GUID}#tag=hello-world`) so developer knows where to find the source component of the dynamically imported module (verified works in all modern browsers)

[0]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data#common_problems
[1]: https://stackoverflow.com/questions/30864573/what-is-a-blob-url-and-why-it-is-used#:~:text=The%20problem%20with%20Data%2DURI%20is%20that%20each%20char%20takes%20two%20bytes%20in%20JavaScript.%20On%20top%20of%20that%20a%2033%25%20is%20added%20due%20to%20the%20Base%2D64%20encoding.%20Blobs%20are%20pure%20binary%20byte%2Darrays%20which%20does%20not%20have%20any%20significant%20overhead%20as%20Data%2DURI%20does%2C%20which%20makes%20them%20faster%20and%20smaller%20to%20handle.