### PR TITLE
Add alternative component module definition

### DIFF
--- a/ponys.js
+++ b/ponys.js
@@ -28,7 +28,13 @@ export default class {
 			)
 		).then(module => {
 			script?.remove();
-			class Component extends (module.default || HTMLElement) {
+			class BaseComponent extends (module.default?.prototype instanceof HTMLElement ? module.default : HTMLElement) { }
+			for (let prop in module) {
+				if (prop === "default" || prop === "constructor") continue;
+				if (prop === "disabledFeatures") BaseComponent[prop] = module[prop]; // static class property
+				else BaseComponent.prototype[prop] = module[prop];
+			}
+			class Component extends BaseComponent {
 				constructor() {
 					super();
 					let root = this;
@@ -38,6 +44,7 @@ export default class {
 					let content = template.cloneNode(true);
 					propagateHost(this, content);
 					root.append(content);
+					this.init?.();
 				}
 			}
 			customElements.define(name, Component, options);


### PR DESCRIPTION
Allow individual method exports as an alternative to export default class (simplifies new user onboarding & potentially demos).

From:
```html
<b>Hello, <slot>world</slot>!</b>
<script type="module" setup>
  export default class extends HTMLElement {
      connectedCallback() {
          console.log("hello-world connectedCallback");
      }
  }
</script>
```

To:

```html
<b>Hello, <slot>world</slot>!</b>
<script type="module" setup>
    export function connectedCallback() {
        console.log("hello-world connectedCallback");
    }
</script>
```

IMO, this enhances the new user experience and allows for easier onboarding into the world of custom web components, and really didn't require that much core library changes to make this possible.

Note that we can also still pass down a base class where these methods will inherit from. For example, this:

```html
<script type="module" setup>
  import BaseComponent from "my-base-component"

  export default class extends BaseComponent {
      doSomething() { ... }
  }
</script>
```

Is equivalent to:

```html
<script type="module" setup>
  export { default } from "my-base-component"

  export function doSomething() { ... }
</script>
```

Since in the library code we assign these to the component class instance `BaseComponent.prototype`, the context of `this` should be the same in either situation.

Functionally, there are two main differences:

1) No constructor option for the direct method exports, however the library will call an `init` function after constructor initialization if defined on the component. Example:

```html
<script type="module" setup>
  export function init() {
    // setup logic (i.e. event bindings)
  }
</script>
```

2) Inheritance is as follows: `PonysComponent` : `BaseComponent_ByMethodExports` : `BaseComponent_ByDefaultExport` : ...? : `HTMLElement`, therefore if overriding a base class method, here is how you would call into original method for each scenario:

Before:
```html
<script type="module" setup>
  import BaseComponent from "my-base-component"

  export default class extends BaseComponent {
      connectedCallback() { 
        super.connectedCallback();
      }
  }
</script>
```

VS after:

```html
<script type="module" setup>
  import BaseComponent from "my-default-component"
  export default BaseComponent

  export function connectedCallback() {
    BaseComponent.prototype.connectedCallback.apply(this, arguments);
  }
</script>
```

Admittedly, this is where using this alternative style starts to fall apart and lose its grandeur. However, I do feel like it still has a strong place in the library. Personally, I setup a base component class that has all the core component setup and state tracking logic, and then each downstream component just needs to expose a render method, like so:

### my-base-component.js
```js
export default class extends HTMLElement {
    constructor() { super(); }

    get root() { return this.shadowRoot ?? this }

    get state() { return this.root._state; }
    set state(value) {
        this.root._state = structuredClone(value);
        this.#renderInternal();
    }

    appendState(obj) {
        if (!obj) return;

        this.state = { ...this.state, ...obj };
    }

    connectedCallback() {
        this.#renderInternal();
    }

    #firstRender = true;

    #renderInternal() {
        if (!this.isConnected) return;

        if (this.render instanceof Function)
            this.render(this.#firstRender)

        this.#firstRender = false;
    }
}
```

### my-first-component.html
```html
<button>Click Me</button><label></label>
<script type="module" setup>
  export { default } from "my-base-component"

  export function render(firstRender) {
    let document = this.root;
    
    if (firstRender) { 
      // setup logic (i.e. event bindings)
      document.querySelector("button").addEventListener("click", doSomething.bind(this));
    }
    
    document.querySelector("label").innerText = this.state.field;
  }

  export function doSomething() { ... }
</script>
```

Obviously not a perfect example, but hopefully shows the point.